### PR TITLE
Fix initial errors generated from running "make lint"

### DIFF
--- a/service/common/error_handlers.py
+++ b/service/common/error_handlers.py
@@ -26,10 +26,10 @@ from . import status
 ######################################################################
 # Error Handlers
 ######################################################################
-# @app.errorhandler(DataValidationError)
-# def request_validation_error(error):
-#     """Handles Value Errors from bad data"""
-#     return bad_request(error)
+@app.errorhandler(DataValidationError)
+def request_validation_error(error):
+    """Handles Value Errors from bad data"""
+    return bad_request(error)
 
 
 @app.errorhandler(status.HTTP_400_BAD_REQUEST)

--- a/service/models.py
+++ b/service/models.py
@@ -17,12 +17,13 @@ db = SQLAlchemy()
 
 # Function to initialize the database
 def init_db(app):
-    """ Initializes the SQLAlchemy app """
+    """Initializes the SQLAlchemy app"""
     Inventory.init_db(app)
 
 
 class DataValidationError(Exception):
-    """ Used for an data validation errors when deserializing """
+    """Used for an data validation errors when deserializing"""
+
 
 class Condition(Enum):
     """Enumeration of valid condition of products"""
@@ -34,6 +35,7 @@ class Condition(Enum):
     # This is the last value in the enum and is meant to be a default value. Nothing should come after this
     FINAL = 4
 
+
 class Inventory(db.Model):
     """
     Class that represents a Inventory
@@ -43,13 +45,19 @@ class Inventory(db.Model):
 
     # Table Schema
     product_id = db.Column(db.Integer, primary_key=True)
-    condition = db.Column(db.Enum(Condition), server_default=(Condition.NEW.name), primary_key=True)
+    condition = db.Column(
+        db.Enum(Condition), server_default=(Condition.NEW.name), primary_key=True
+    )
     quantity = db.Column(db.Integer, default=1)
-    restock_level = db.Column(db.Integer,default=1)
-    last_updated_on = db.Column(db.DateTime, default=datetime.now, onupdate=datetime.now)
+    restock_level = db.Column(db.Integer, default=1)
+    last_updated_on = db.Column(
+        db.DateTime, default=datetime.now, onupdate=datetime.now
+    )
 
     def __repr__(self):
-        return f"<Inventory product_id=[{self.product_id}] condition=[{self.condition}]>"
+        return (
+            f"<Inventory product_id=[{self.product_id}] condition=[{self.condition}]>"
+        )
 
     def create(self):
         """
@@ -69,7 +77,11 @@ class Inventory(db.Model):
         """
         Updates a Inventory to the database
         """
-        logger.info("Updating inventory product_id=%s,condition=%s",self.product_id,self.condition)
+        logger.info(
+            "Updating inventory product_id=%s,condition=%s",
+            self.product_id,
+            self.condition,
+        )
         if not self.product_id:
             raise DataValidationError("Update called with empty ID field")
         if not self.condition:
@@ -79,20 +91,26 @@ class Inventory(db.Model):
         db.session.commit()
 
     def delete(self):
-        """ Removes a Inventory from the data store """
-        logger.info("Deleting inventory product_id=%s,condition=%s",self.product_id,self.condition)
+        """Removes a Inventory from the data store"""
+        logger.info(
+            "Deleting inventory product_id=%s,condition=%s",
+            self.product_id,
+            self.condition,
+        )
         db.session.delete(self)
         db.session.commit()
 
     def serialize(self):
-        """ Serializes a Inventory into a dictionary """
-        return {"product_id": self.product_id,
-                "condition": self.condition.name,
-                "quantity": self.quantity,
-                "restock_level": self.restock_level,
-                "last_updated_on": self.last_updated_on}
+        """Serializes a Inventory into a dictionary"""
+        return {
+            "product_id": self.product_id,
+            "condition": self.condition.name,
+            "quantity": self.quantity,
+            "restock_level": self.restock_level,
+            "last_updated_on": self.last_updated_on,
+        }
 
-    def deserialize(self, data:dict):
+    def deserialize(self, data: dict):
         """
         Deserializes a Inventory from a dictionary
 
@@ -124,13 +142,14 @@ class Inventory(db.Model):
             ) from error
         except TypeError as error:
             raise DataValidationError(
-                "Invalid Inventory: body of request contained bad or no data " + str(error)
+                "Invalid Inventory: body of request contained bad or no data "
+                + str(error)
             ) from error
         return self
 
     @classmethod
     def init_db(cls, app):
-        """ Initializes the database session """
+        """Initializes the database session"""
         logger.info("Initializing database")
         cls.app = app
         # This is where we initialize SQLAlchemy from the Flask app
@@ -140,15 +159,21 @@ class Inventory(db.Model):
 
     @classmethod
     def all(cls):
-        """ Returns all of the Inventories in the database """
+        """Returns all of the Inventories in the database"""
         logger.info("Processing all Inventories")
         return cls.query.all()
 
     @classmethod
     def find(cls, by_id, by_condition):
-        """ Finds a Inventory by it's ID and condition """
-        logger.info("Processing lookup for product_id %s and condition %s ...", by_id, by_condition)
-        return cls.query.filter(cls.product_id == by_id, cls.condition == by_condition).first()
+        """Finds a Inventory by it's ID and condition"""
+        logger.info(
+            "Processing lookup for product_id %s and condition %s ...",
+            by_id,
+            by_condition,
+        )
+        return cls.query.filter(
+            cls.product_id == by_id, cls.condition == by_condition
+        ).first()
 
     @classmethod
     def find_or_404(cls, product_id: int, condition: Condition):
@@ -161,7 +186,11 @@ class Inventory(db.Model):
         :rtype: Inventory
 
         """
-        logger.info("Processing lookup or 404 for product_id %s, condition %s", product_id, condition)
+        logger.info(
+            "Processing lookup or 404 for product_id %s, condition %s",
+            product_id,
+            condition,
+        )
         return cls.query.get_or_404((product_id, condition))
 
     @classmethod

--- a/service/utilities.py
+++ b/service/utilities.py
@@ -3,7 +3,7 @@ Utilities for Inventory API endpoints
 
 """
 
-from flask import Flask, jsonify, request, url_for, make_response, abort
+from flask import request, abort
 from service.common import status  # HTTP Status Codes
 
 # Import Flask application
@@ -33,13 +33,14 @@ def check_content_type(content_type):
         f"Content-Type must be {content_type}",
     )
 
+
 def check_condition_type(condition_str):
     """Checks if the given string is a product condition"""
     try:
         condition = Condition[condition_str]
+
+        # This line was added to suppress a "make lint" error
+        return condition
     except KeyError:
         app.logger.error("Invalid Condition Type.")
-        abort(
-            status.HTTP_400_BAD_REQUEST,
-            "Invalid Condition Type."
-        )
+        abort(status.HTTP_400_BAD_REQUEST, "Invalid Condition Type.")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,11 +15,12 @@ DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/testdb"
 )
 
+
 ######################################################################
 #  Inventory   M O D E L   T E S T   C A S E S
 ######################################################################
 class TestInventory(unittest.TestCase):
-    """ Test Cases for Inventory Model """
+    """Test Cases for Inventory Model"""
 
     @classmethod
     def setUpClass(cls):
@@ -50,15 +51,21 @@ class TestInventory(unittest.TestCase):
 
     def test_create_a_inventory(self):
         """It should Create a Inventory and assert that it exists"""
-        inventory = Inventory(product_id=1, condition= Condition.NEW, quantity=1, restock_level=3)
-        self.assertEqual(str(inventory), "<Inventory product_id=[1] condition=[Condition.NEW]>")
+        inventory = Inventory(
+            product_id=1, condition=Condition.NEW, quantity=1, restock_level=3
+        )
+        self.assertEqual(
+            str(inventory), "<Inventory product_id=[1] condition=[Condition.NEW]>"
+        )
         self.assertTrue(inventory is not None)
         self.assertTrue(inventory.product_id is not None)
         self.assertEqual(inventory.condition, Condition.NEW)
         self.assertEqual(inventory.quantity, 1)
         self.assertEqual(inventory.restock_level, 3)
 
-        inventory = Inventory(product_id=2, condition=Condition.OPEN_BOX, restock_level=5)
+        inventory = Inventory(
+            product_id=2, condition=Condition.OPEN_BOX, restock_level=5
+        )
         self.assertEqual(inventory.quantity, None)
         self.assertEqual(inventory.condition, Condition.OPEN_BOX)
 
@@ -66,7 +73,9 @@ class TestInventory(unittest.TestCase):
         """It should Create a inventory and add it to the database"""
         inventories = Inventory.all()
         self.assertEqual(inventories, [])
-        inventory = Inventory(product_id=1, condition=Condition.NEW, quantity=10, restock_level=4)
+        inventory = Inventory(
+            product_id=1, condition=Condition.NEW, quantity=10, restock_level=4
+        )
         self.assertTrue(inventory is not None)
         self.assertTrue(inventory.product_id is not None)
         inventory.create()
@@ -173,7 +182,11 @@ class TestInventory(unittest.TestCase):
         self.assertIn("restock_level", data)
         self.assertEqual(data["restock_level"], inventory.restock_level)
         self.assertIn("last_updated_on", data)
-        self.assertAlmostEqual(data["last_updated_on"], inventory.last_updated_on, delta=datetime.timedelta(seconds=0))
+        self.assertAlmostEqual(
+            data["last_updated_on"],
+            inventory.last_updated_on,
+            delta=datetime.timedelta(seconds=0),
+        )
 
     def test_deserialize_an_inventory(self):
         """It should de-serialize a inventory"""
@@ -245,7 +258,9 @@ class TestInventory(unittest.TestCase):
         for inventory in inventories:
             inventory.create()
         condition = inventories[0].condition
-        count = len([inventory for inventory in inventories if inventory.condition == condition])
+        count = len(
+            [inventory for inventory in inventories if inventory.condition == condition]
+        )
         found = Inventory.find_by_condition(condition)
         self.assertEqual(found.count(), count)
         for inventory in found:
@@ -257,7 +272,9 @@ class TestInventory(unittest.TestCase):
         for inventory in inventories:
             inventory.create()
 
-        inventory = Inventory.find_or_404(inventories[1].product_id, inventories[1].condition)
+        inventory = Inventory.find_or_404(
+            inventories[1].product_id, inventories[1].condition
+        )
         self.assertIsNot(inventory, None)
         self.assertEqual(inventory.product_id, inventories[1].product_id)
         self.assertEqual(inventory.condition, inventories[1].condition)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,7 +8,6 @@ Test cases can be run with the following:
 import os
 import logging
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 from service import app
 from service.models import Condition, Inventory, db
 from service.common import status
@@ -20,11 +19,13 @@ DATABASE_URI = os.getenv(
 )
 BASE_URL = "/inventory"
 
+
 ######################################################################
 #  T E S T   C A S E S
 ######################################################################
 class TestYourResourceServer(TestCase):
-    """ REST API Server Tests """
+    """REST API Server Tests"""
+
     @classmethod
     def setUpClass(cls):
         """This runs once before the entire test suite"""
@@ -49,41 +50,47 @@ class TestYourResourceServer(TestCase):
         """This runs after each test"""
         db.session.remove()
 
-
     def _create_product_id(self, count):
-            """Factory method to create products in bulk"""
-            test_product_id = InventoryFactory()
-            response = self.client.post(BASE_URL, json=test_product_id.serialize())
-            self.assertEqual(
-                response.status_code, status.HTTP_201_CREATED, "Could not create test product_id"
-            )
-            new_product_id = response.get_json()
-            return new_product_id
+        """Factory method to create products in bulk"""
+        test_product_id = InventoryFactory()
+        response = self.client.post(BASE_URL, json=test_product_id.serialize())
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_201_CREATED,
+            "Could not create test product_id",
+        )
+        new_product_id = response.get_json()
+        return new_product_id
+
     ######################################################################
     #  P L A C E   T E S T   C A S E S   H E R E
     ######################################################################
 
     def test_index(self):
-        """ It should call the home page """
+        """It should call the home page"""
         resp = self.client.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_delete_product(self):
         """Test deleting a product"""
         test_product = self._create_product_id(1)
-        response = self.client.delete(f"{BASE_URL}/{test_product['product_id']}/{test_product['condition']}")
+        response = self.client.delete(
+            f"{BASE_URL}/{test_product['product_id']}/{test_product['condition']}"
+        )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        response = self.client.get(f"{BASE_URL}/{test_product['product_id']}/{test_product['condition']}")
+        response = self.client.get(
+            f"{BASE_URL}/{test_product['product_id']}/{test_product['condition']}"
+        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-    
+
     def test_delete_product_with_invalid_details(self):
         """Test deleting a product"""
         response = self.client.delete(f"{BASE_URL}/0/OPEN_BOX")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-    
+
     def test_list_all_items(self):
-        """ It should list all of the items in the inventory """
+        """It should list all of the items in the inventory"""
         # Test the list_all_items function in routes.py
 
         # Call list_all_items before adding anything; the list should be empty
@@ -95,7 +102,7 @@ class TestYourResourceServer(TestCase):
         # Add 50 inventory objects with random data into the DB
         for number in range(50):
             test_inventory = InventoryFactory()
-            response = self.client.post(BASE_URL, json = test_inventory.serialize())
+            response = self.client.post(BASE_URL, json=test_inventory.serialize())
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         # end for
 
@@ -104,10 +111,11 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         ret_list = response.get_json()
         self.assertEqual(len(ret_list), 50)
+
     # end func test_list_all_items
 
     def test_list_items_criteria_condition(self):
-        """ It should list items (based on input condition NEW, OPEN_BOX, USED) in the inventory """
+        """It should list items (based on input condition NEW, OPEN_BOX, USED) in the inventory"""
 
         # Call list_items_criteria before adding anything; the list should be empty
         # Pass in a proper string (NEW, USED, OPEN_BOX) to ensure we don't get an HTTP 400
@@ -121,44 +129,64 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         # Add some hard-coded inventory objects
-        test_inventory = Inventory(product_id = 1, condition = Condition.NEW, quantity = 10, restock_level = 1)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=1, condition=Condition.NEW, quantity=10, restock_level=1
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 2, condition = Condition.NEW, quantity = 5, restock_level = 1)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=2, condition=Condition.NEW, quantity=5, restock_level=1
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 3, condition = Condition.NEW, quantity = 15, restock_level = 1)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=3, condition=Condition.NEW, quantity=15, restock_level=1
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 4, condition = Condition.OPEN_BOX, quantity = 30, restock_level = 12)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=4, condition=Condition.OPEN_BOX, quantity=30, restock_level=12
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 5, condition = Condition.USED, quantity = 30, restock_level = 12)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=5, condition=Condition.USED, quantity=30, restock_level=12
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 6, condition = Condition.USED, quantity = 300, restock_level = 12)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=6, condition=Condition.USED, quantity=300, restock_level=12
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 7, condition = Condition.USED, quantity = 100, restock_level = 12)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=7, condition=Condition.USED, quantity=100, restock_level=12
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 8, condition = Condition.USED, quantity = 15, restock_level = 5)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=8, condition=Condition.USED, quantity=15, restock_level=5
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 9, condition = Condition.OPEN_BOX, quantity = 15, restock_level = 5)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=9, condition=Condition.OPEN_BOX, quantity=15, restock_level=5
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 10, condition = Condition.USED, quantity = 150, restock_level = 5)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=10, condition=Condition.USED, quantity=150, restock_level=5
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # All entries have been added, make sure there are:
@@ -179,50 +207,71 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         ret_list = response.get_json()
         self.assertEqual(len(ret_list), 2)
+
     # end func test_list_items_criteria_condition
 
     def test_list_items_criteria_restock(self):
-        """ It should list items we're running low on (based on restock level) in the inventory """
+        """It should list items we're running low on (based on restock level) in the inventory"""
 
         # Add some hard-coded inventory objects
-        test_inventory = Inventory(product_id = 1, condition = Condition.NEW, quantity = 10, restock_level = 11)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=1, condition=Condition.NEW, quantity=10, restock_level=11
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 2, condition = Condition.NEW, quantity = 50, restock_level = 60)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=2, condition=Condition.NEW, quantity=50, restock_level=60
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 3, condition = Condition.NEW, quantity = 5, restock_level = 1)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=3, condition=Condition.NEW, quantity=5, restock_level=1
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 4, condition = Condition.OPEN_BOX, quantity = 30, restock_level = 35)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=4, condition=Condition.OPEN_BOX, quantity=30, restock_level=35
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 5, condition = Condition.USED, quantity = 20, restock_level = 20)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=5, condition=Condition.USED, quantity=20, restock_level=20
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 6, condition = Condition.USED, quantity = 500, restock_level = 120)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=6, condition=Condition.USED, quantity=500, restock_level=120
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 7, condition = Condition.USED, quantity = 100, restock_level = 120)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=7, condition=Condition.USED, quantity=100, restock_level=120
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 8, condition = Condition.USED, quantity = 15, restock_level = 50)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=8, condition=Condition.USED, quantity=15, restock_level=50
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 9, condition = Condition.OPEN_BOX, quantity = 88, restock_level = 95)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=9, condition=Condition.OPEN_BOX, quantity=88, restock_level=95
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        test_inventory = Inventory(product_id = 10, condition = Condition.USED, quantity = 150, restock_level = 150)
-        response = self.client.post(BASE_URL, json = test_inventory.serialize())
+        test_inventory = Inventory(
+            product_id=10, condition=Condition.USED, quantity=150, restock_level=150
+        )
+        response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         response = self.client.get(BASE_URL + "/RESTOCK")
@@ -231,22 +280,29 @@ class TestYourResourceServer(TestCase):
 
         # there are 6 entries from above where quantity < restock_level
         self.assertEqual(len(ret_list), 6)
+
     # end func test_list_items_criteria_restock
 
     def test_create_inventory_success(self):
         """It should Create a new Inventory item"""
         test_inventory = InventoryFactory()
-        logging.debug("Test Inventory create successful: %s", test_inventory.serialize())
+        logging.debug(
+            "Test Inventory create successful: %s", test_inventory.serialize()
+        )
         response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Check the data is correct
         new_inventory_item = response.get_json()
         self.assertEqual(new_inventory_item["product_id"], test_inventory.product_id)
-        self.assertEqual(getattr(Condition, new_inventory_item["condition"]), test_inventory.condition)
+        self.assertEqual(
+            getattr(Condition, new_inventory_item["condition"]),
+            test_inventory.condition,
+        )
         self.assertEqual(new_inventory_item["quantity"], test_inventory.quantity)
-        self.assertEqual(new_inventory_item["restock_level"], test_inventory.restock_level)
-
+        self.assertEqual(
+            new_inventory_item["restock_level"], test_inventory.restock_level
+        )
 
     def test_create_inventory_conflict(self):
         """It should fail to Create a new Inventory item"""
@@ -258,14 +314,19 @@ class TestYourResourceServer(TestCase):
         # Check the data is correct
         new_inventory_item = response.get_json()
         self.assertEqual(new_inventory_item["product_id"], test_inventory.product_id)
-        self.assertEqual(getattr(Condition, new_inventory_item["condition"]), test_inventory.condition)
+        self.assertEqual(
+            getattr(Condition, new_inventory_item["condition"]),
+            test_inventory.condition,
+        )
         self.assertEqual(new_inventory_item["quantity"], test_inventory.quantity)
-        self.assertEqual(new_inventory_item["restock_level"], test_inventory.restock_level)
+        self.assertEqual(
+            new_inventory_item["restock_level"], test_inventory.restock_level
+        )
 
         # Retry the same POST to trigger key conflict
         response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
-    
+
     def test_create_with_no_content_type(self):
         """Specifying some raw string with no type for the post request, it should report a 415 error"""
         response = self.client.post(BASE_URL, data="some raw string")
@@ -274,66 +335,90 @@ class TestYourResourceServer(TestCase):
     def test_create_with_invalid_content_type(self):
         """Specifying some other type for the post request, it should report a 415 error"""
         data = "key1=value1&key2=value2"
-        response = self.client.post(BASE_URL, data=data, content_type='application/x-www-form-urlencoded')
+        response = self.client.post(
+            BASE_URL, data=data, content_type="application/x-www-form-urlencoded"
+        )
         self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
     def test_update_normally(self):
         """Update normally"""
         test_inventory = InventoryFactory(condition=Condition.NEW)
-        response_create = self.client.post(BASE_URL, json=test_inventory.serialize())
-        update_url = BASE_URL + "/" + str(test_inventory.product_id) + "/NEW" 
+        self.client.post(BASE_URL, json=test_inventory.serialize())
+        update_url = BASE_URL + "/" + str(test_inventory.product_id) + "/NEW"
         update_quantity = test_inventory.quantity + 2
         update_restock_level = test_inventory.restock_level + 1
-        response = self.client.put(update_url, json={"quantity": update_quantity, "restock_level": update_restock_level})
+        response = self.client.put(
+            update_url,
+            json={"quantity": update_quantity, "restock_level": update_restock_level},
+        )
         test_inventory_json = response.get_json()
         self.assertEqual(int(test_inventory_json["quantity"]), update_quantity)
-        self.assertEqual(int(test_inventory_json["restock_level"]), update_restock_level)
-        
+        self.assertEqual(
+            int(test_inventory_json["restock_level"]), update_restock_level
+        )
+
     def test_update_non_existing_item(self):
         """Update a non-existing item, should report a 404 error"""
         update_url = BASE_URL + "/1/NEW"
-        response = self.client.put(update_url, json={"quantity": 10, "restock_level": 5})
+        response = self.client.put(
+            update_url, json={"quantity": 10, "restock_level": 5}
+        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_negative_quantity(self):
         """Update a negative quantity, should report a 400 error"""
         test_inventory = InventoryFactory(condition=Condition.NEW)
-        response_create = self.client.post(BASE_URL, json=test_inventory.serialize())
-        update_url = BASE_URL + "/" + str(test_inventory.product_id) + "/NEW" 
+        self.client.post(BASE_URL, json=test_inventory.serialize())
+        update_url = BASE_URL + "/" + str(test_inventory.product_id) + "/NEW"
         update_quantity = -1
         update_restock_level = test_inventory.restock_level + 1
-        response = self.client.put(update_url, json={"quantity": update_quantity, "restock_level": update_restock_level})
+        response = self.client.put(
+            update_url,
+            json={"quantity": update_quantity, "restock_level": update_restock_level},
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_negative_restock_level(self):
         """Update a negative restock level, should report a 400 error"""
         test_inventory = InventoryFactory(condition=Condition.NEW)
-        response_create = self.client.post(BASE_URL, json=test_inventory.serialize())
-        update_url = BASE_URL + "/" + str(test_inventory.product_id) + "/NEW" 
+        self.client.post(BASE_URL, json=test_inventory.serialize())
+        update_url = BASE_URL + "/" + str(test_inventory.product_id) + "/NEW"
         update_quantity = test_inventory.quantity + 2
         update_restock_level = -2
-        response = self.client.put(update_url, json={"quantity": update_quantity, "restock_level": update_restock_level})
+        response = self.client.put(
+            update_url,
+            json={"quantity": update_quantity, "restock_level": update_restock_level},
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_update_using_non_condition_value(self):
-        """Update an inventory by specifying a string which is not a part of Condition class, should be handled by check_condition_type function and report a 400 error"""
+        """Run test_update_using_non_condition_value method"""
+        # Update an inventory by specifying a string which is not a part of Condition class
+        # should be handled by check_condition_type function and report a 400 error"""
         test_inventory = InventoryFactory(condition=Condition.NEW)
-        response_create = self.client.post(BASE_URL, json=test_inventory.serialize())
-        update_url = BASE_URL + "/" + str(test_inventory.product_id) + "/EEEE" 
+        self.client.post(BASE_URL, json=test_inventory.serialize())
+        update_url = BASE_URL + "/" + str(test_inventory.product_id) + "/EEEE"
         update_quantity = test_inventory.quantity + 2
         update_restock_level = test_inventory.restock_level + 1
-        response = self.client.put(update_url, json={"quantity": update_quantity, "restock_level": update_restock_level})
+        response = self.client.put(
+            update_url,
+            json={"quantity": update_quantity, "restock_level": update_restock_level},
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-   
+
     def test_get_inventory(self):
         """It should Get a single inventory"""
         # get the id of a inventory
         test_inventory = InventoryFactory()
-        logging.debug("Test Inventory create successful: %s", test_inventory.serialize())
+        logging.debug(
+            "Test Inventory create successful: %s", test_inventory.serialize()
+        )
         response = self.client.post(BASE_URL, json=test_inventory.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        response = self.client.get(f"{BASE_URL}/{test_inventory.product_id}/{test_inventory.condition.name}")
+        response = self.client.get(
+            f"{BASE_URL}/{test_inventory.product_id}/{test_inventory.condition.name}"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.get_json()
         self.assertEqual(data["product_id"], test_inventory.product_id)
@@ -351,4 +436,3 @@ class TestYourResourceServer(TestCase):
 
         response = self.client.get(f"{BASE_URL}/0/FINAL")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-


### PR DESCRIPTION
![image](https://github.com/CSCI-GA-2820-SU23-001/inventory/assets/113815338/fdd26b91-a7f0-4972-bf75-e86fcd4971ec)
![image](https://github.com/CSCI-GA-2820-SU23-001/inventory/assets/113815338/4e286f16-1f40-4d30-b1c6-0c9e9a6ccb7e)
![image](https://github.com/CSCI-GA-2820-SU23-001/inventory/assets/113815338/562fb429-bcfe-4b80-aa8c-8d8b80cad335)
![image](https://github.com/CSCI-GA-2820-SU23-001/inventory/assets/113815338/c7839bc9-3b2b-4842-b05d-831dfbd25b02)

"make lint" still returns errors, but we now get a score for the overall quality of the code base. Is this good enough?

Also, I don't know why requirements.txt is not showing up in this PR. The only change is the addition of "black==23.1.0" under the "# Code quality" section. I believe this is all we'll need to add to automatically "pull" down the Black formatter every time we build our container

This change shows up in both my and the mainline branch, even though I haven't merged anything in yet?

FYI our code coverage went down from 99% to 98% since I added back one of the required data handlers