### PR TITLE
Clean up db in tearDown function

### DIFF
--- a/tests/parent_models.py
+++ b/tests/parent_models.py
@@ -38,6 +38,8 @@ class TestInventoryModel(unittest.TestCase):
 
     def tearDown(self):
         """This runs after each test"""
+        db.session.query(Inventory).delete()  # clean up the test
+        db.session.commit()
         db.session.remove()
 
 
@@ -66,4 +68,6 @@ class TestResourceServer(unittest.TestCase):
 
     def tearDown(self):
         """This runs after each test"""
+        db.session.query(Inventory).delete()  # clean up the test
+        db.session.commit()
         db.session.remove()


### PR DESCRIPTION
The tear down function needs to delete database entries.
Previously the database was only cleared before a test is called. If the last test adds data to the database, the database was never cleared as there are no more tests to setup.
